### PR TITLE
Fix links, reduce image size

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -15,7 +15,6 @@ params:
   Address: "Piet Heinkade 179, 1019 HC"
   City: "Amsterdam"
   State: "The Netherlands"
-  Images: ["/img/background.jpg"]
   GoogleMapsKey: "AIzaSyBIn3t-h0jnfK1qaYz-WOkr_lG3ku8jpjw"
 
   # Active sections on the website to deactivate comment out with '#'

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -34,8 +34,8 @@
         {{ end }}
 
         <footer class="footer">
-          <p>Made with ♥ by <a href="https://github.com/braziljs/conf-boilerplate" target="_blank">Conf Boilerplate</a> :)</p>
-          <p>Code available on <a href="https://github.com/braziljs/conf-boilerplate" target="_blank">Github</a> :)</p>
+          <p>Code available on <a href="https://github.com/cloudnative-amsterdam/hugo-website" target="_blank">Github</a> :)</p>
+          <p><small>Website based on <a href="https://github.com/braziljs/conf-boilerplate" target="_blank">Conf Boilerplate</a> :)</small></p>
         </footer>
       </div>
     </div>

--- a/layouts/partials/sponsors.html
+++ b/layouts/partials/sponsors.html
@@ -1,6 +1,6 @@
 <h2 class="section-title">{{ .titles.sponsors }}</h2>
 
-<p>Interested in sharing part of this Cloud Native journey with us? Have a look at <a href="static/pdf/sponsor_cndams19.v0.1.pdf">sponsor
+<p>Interested in sharing part of this Cloud Native journey with us? Have a look at <a href="pdf/sponsor_cndams19.v0.1.pdf">sponsor
 package</a> and get in touch via email to <a href="mailto:info@cloudnative.amsterdam">info@cloudnative.amsterdam</a>
 </p>
 


### PR DESCRIPTION
- Fix website Github repo link.
- Fix sponsorship PDF link.
- Reduce cover image size.
   - Reduced the width from 7000+ to 2000 pixels.
   - Compressed the image using ImageOptim.
   - Size reduced from 7.8 MB to 350 KB.